### PR TITLE
Fixed error if search parameter is missing

### DIFF
--- a/src/Tablelize.php
+++ b/src/Tablelize.php
@@ -205,7 +205,7 @@ class Tablelize
         $sortOrder = $original['so'];
 
         // Search
-        $search = $original['s'];
+        $search = isset($original['s']) ? $original['s'] : null;
 
         // Check previous page size
         if($previousPageSize) {


### PR DESCRIPTION
Sometimes $original['s'] might not be set