### PR TITLE
Use an md5 of the url as id

### DIFF
--- a/src/Tablelize.php
+++ b/src/Tablelize.php
@@ -138,7 +138,7 @@ class Tablelize
 
         $this->options = new TablelizeOptions([
             'url'          => $url,
-            'id'           => ( isset($options['id']) ? $options['id'] : 'tl_' . str_replace('/', '_', $url) ),
+            'id'           => ( isset($options['id']) ? $options['id'] : 'tl_' . md5($url) ),
             'idField'      => $idField,
             'fields'       => $fields,
             'queryString'  => ( isset($options['queryString']) ? $options['queryString'] : [] ),


### PR DESCRIPTION
Currently Tablelize will fail if the url contains a dot (.) because of Document.querySelector interpreting it as a class name